### PR TITLE
Replace 'master' branch with 'main' branch

### DIFF
--- a/.github/workflows/node-check-code.yaml
+++ b/.github/workflows/node-check-code.yaml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - 'wip-**'
       - '**-wip'
-      - 'master'
+      - 'main'
       - 'alpha'
       - 'beta'
       - 'next'
@@ -17,6 +17,7 @@ jobs:
     env:
       CI: true
       NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
+      STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest
 
@@ -30,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Fetch
-        run: git fetch --prune --unshallow && git fetch origin 'master:master'
+        run: git fetch --prune --unshallow && git fetch origin "$STABLE_RELEASE_BRANCH:$STABLE_RELEASE_BRANCH"
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/node-prerelease.yaml
+++ b/.github/workflows/node-prerelease.yaml
@@ -23,6 +23,7 @@ jobs:
       GPG_KEY_ID: ${{ secrets.SPQR_BOT_GPG_KEY_ID }}
       NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
       NPM_READ_AND_PUBLISH_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN }}
+      STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest
 
@@ -40,7 +41,7 @@ jobs:
       - name: Fetch
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          git fetch --unshallow origin 'master:master'
+          git fetch --unshallow origin "$STABLE_RELEASE_BRANCH:$STABLE_RELEASE_BRANCH"
           git fetch origin $(git symbolic-ref --short HEAD)
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/node-stable-release.yaml
+++ b/.github/workflows/node-stable-release.yaml
@@ -3,7 +3,7 @@ name: Stable release
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -21,6 +21,7 @@ jobs:
       GPG_KEY_ID: ${{ secrets.SPQR_BOT_GPG_KEY_ID }}
       NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
       NPM_READ_AND_PUBLISH_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN }}
+      STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest
 
@@ -38,7 +39,7 @@ jobs:
       - name: Fetch
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          git fetch --unshallow origin master
+          git fetch --unshallow origin $STABLE_RELEASE_BRANCH
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -129,4 +130,4 @@ jobs:
         run: git push --tags origin $VERSION_STAGE
       - name: Update next branch
         if: success()
-        run: git fetch origin next && git checkout next && git merge --ff-only master && git push origin next
+        run: git fetch origin next && git checkout next && git merge --ff-only $STABLE_RELEASE_BRANCH && git push origin next

--- a/README.md
+++ b/README.md
@@ -27,8 +27,13 @@ Quick Release analyzes the following data to determine the next version number:
 The `master` branch is treated as the stable-release branch. A version bump on this branch
 results in a new version number in the form `X.X.X` (example: `1.0.0`).
 
-All other branches are treated as prerelease branches. A version bump on a prerelease branch
-results in a new version number in the form `X.X.X-<BRANCH NAME>.X` (example: `1.0.0-beta.1`).
+If the stable-release branch has a name other than `master`, set it using the `STABLE_RELEASE_BRANCH`
+environment variable in each of the workflow files. Note that the use of `master` is deprecated,
+and `main` will become the default stable-release branch name in a future version of this library.
+
+All branches other than the stable-release branch are treated as prerelease branches. A version bump
+on a prerelease branch results in a new version number in the form `X.X.X-<BRANCH NAME>.X`
+(example: `1.0.0-beta.1`).
 
 ## How to install
 


### PR DESCRIPTION
This change replaces the `master` branch with the `main` branch.

It also serves as a test of the logic that allows the name of the stable-release branch to be customized:

- The `master` branch has already been deleted
- `STABLE_RELEASE_BRANCH` has been set to `main` in each of the GitHub workflows

The version-bump should be able to compute a new version number relative to the `main` branch.